### PR TITLE
Fix syntax error in few_shot_examples.py

### DIFF
--- a/few_shot_examples.py
+++ b/few_shot_examples.py
@@ -58,7 +58,7 @@ Severity:  MEDIUM
 
 
 
-— Two examples covering different document structures —
+# — Two examples covering different document structures —
 """
 Extract: contract_value, effective_date, payment_terms
 


### PR DESCRIPTION
Stray em-dash line outside any string literal caused a SyntaxError. Comment it out so it stays as a section header but no longer breaks parsing. @aakash1999 